### PR TITLE
Add basic CORS support to enable Firefox requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ var mongodb = Promise.promisifyAll(require('mongodb'));
 var debug = require('debug')('fbtrex');
 var nconf = require('nconf');
 var jade = require('jade');
+var cors = require('cors');
 
 var utils = require('./lib/utils');
 var escviAPI = require('./lib/allversions');
@@ -93,6 +94,7 @@ var dispatchPromise = function(name, req, res) {
 server.listen(nconf.get('port'), '127.0.0.1');
 console.log("  Port " + nconf.get('port') + " listening");
 /* configuration of express4 */
+app.use(cors());
 app.use(bodyParser.json({limit: '3mb'}));
 app.use(bodyParser.urlencoded({limit: '3mb', extended: true}));
 
@@ -179,7 +181,7 @@ app.get('/facebook.tracking.exposed.user.js', function (req, res) {
 });
 
 
-/* development: the local JS are pick w/out "npm run build" every time, and 
+/* development: the local JS are pick w/out "npm run build" every time, and
  * our locally developed scripts stay in /js/local */
 if(nconf.get('development') === 'true') {
     console.log(redOn + "ઉ DEVELOPMENT = serving JS from src" + redOff);

--- a/lib/onboarding.js
+++ b/lib/onboarding.js
@@ -85,7 +85,7 @@ function validateKey(req) {
     var curlMock = nconf.get('curlMock');
 
     var bodyPromise = curlMock ?
-        retrieveHTMLviaFile(curlMock) : 
+        retrieveHTMLviaFile(curlMock) :
         retrieveHTMLviaCurl(permalink);
 
     return bodyPromise
@@ -126,18 +126,13 @@ function validateKey(req) {
                     keyTime: new Date(),
                     lastInfo: new Date()
                 })
-                .return({ "json": { 
+                .return({ "json": {
                     "result": "OK",
                     "userSecret": userSecret
                 }});
             }
         })
         .then(function(retVal) {
-            /* whatever return value need a CORS header */
-            retVal.headers = {
-                "Access-Control-Allow-Origin":
-                "https://facebook.com"
-            }
             return retVal;
         })
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "node app"
   },
   "author": "Claudio Agosti <claudio@tracking.exposed>, https://github.com/tracking-exposed/facebook/graphs/contributors",
-  "license" : "(ISC OR GPL-3.0)",
+  "license": "(ISC OR GPL-3.0)",
   "dependencies": {
     "bluebird": "^3.4.1",
     "body-parser": "^1.15.2",
@@ -18,6 +18,7 @@
     "c3": "^0.4.11",
     "cheerio": "^0.22.0",
     "cookie": "^0.3.1",
+    "cors": "^2.8.1",
     "crypto": "0.0.3",
     "d3": "^3.5.17",
     "debug": "^2.2.0",


### PR DESCRIPTION
I noticed that a Firefox extension cannot issue XHR if CORS is not enabled server side.

This PR is to enable **all** CORS requests to our API using this middleware:
 - https://github.com/expressjs/cors

I think it's **not** a problem to whitelist everything.